### PR TITLE
Bump to 4.3.2

### DIFF
--- a/libwbxml.spec
+++ b/libwbxml.spec
@@ -1,12 +1,30 @@
 Name:           libwbxml
-Version:        0.11.2
-Release:        3%{?dist}
+Version:        0.11.6
+Release:        1%{?dist}
 Summary:        Library and tools to parse, encode and handle WBXML documents
-Group:          System Environment/Libraries
+## Used and installed:
+# NEWS:                             ???
+# GNU-LGPL:                         LGPLv2+
+# COPYING:                          LGPLv2+
+# Other files:                      LGPLv2+
+## Not installed:
+# cmake/modules/FindECal1.2.cmake:  BSD
+# cmake/modules/FindIconv.cmake:    GPLv3+
+## Not used:
+# win32/leaktrack/leaktrack.h:      GPLv2+
+# win32/leaktrack/COPYING.txt:      BSD with advertising
+# win32/expat/README.txt:           MIT
 License:        LGPLv2+
-URL:            https://libwbxml.opensync.org/
+URL:            https://github.com/%{name}/%{name}
 Source:         http://downloads.sourceforge.net/%{name}/%{name}-%{version}.tar.bz2
-BuildRequires:  cmake, expat-devel, perl
+BuildRequires:  cmake >= 2.4
+BuildRequires:  coreutils
+BuildRequires:  expat-devel
+BuildRequires:  gcc
+BuildRequires:  make
+BuildRequires:  pkgconfig(check)
+# Tests:
+BuildRequires:  perl-interpreter
 Obsoletes:      wbxml2 <= 0.9.3
 
 %description
@@ -16,9 +34,9 @@ representation of XML, defined by the Wap Forum, and used to reduce
 bandwidth in mobile communications.
 
 %package devel
-Group:         Development/Libraries
 Summary:       Development files of %{name}
 Requires:      %{name}%{?_isa} = %{version}-%{release}
+Requires:      gcc
 Requires:      pkgconfig
 Provides:      wbxml2-devel = %{version}-%{release}
 Obsoletes:     wbxml2-devel <= 0.9.3
@@ -34,34 +52,85 @@ developing applications that use %{name}.
 # Upstream does not support in-source-directory building
 mkdir -p %{_target_platform}
 pushd %{_target_platform}
-%cmake ..
+%cmake \
+    -DBUILD_SHARED_LIBS:BOOL=ON \
+    -DBUILD_STATIC_LIBS:BOOL=OFF \
+    -DENABLE_INSTALL_DOC:BOOL=OFF \
+    -DENABLE_UNIT_TEST:BOOL=ON \
+    -DWBXML_LIB_VERBOSE:BOOL=OFF \
+    -DWBXML_ENCODER_USE_STRTBL:BOOL=ON \
+    -DWBXML_SUPPORT_AIRSYNC:BOOL=ON \
+    -DWBXML_SUPPORT_CO:BOOL=ON \
+    -DWBXML_SUPPORT_CONML=ON \
+    -DWBXML_SUPPORT_DRMREL:BOOL=ON \
+    -DWBXML_SUPPORT_EMN:BOOL=ON \
+    -DWBXML_SUPPORT_OTA_SETTINGS:BOOL=ON \
+    -DWBXML_SUPPORT_PROV:BOOL=ON \
+    -DWBXML_SUPPORT_SI:BOOL=ON \
+    -DWBXML_SUPPORT_SL:BOOL=ON \
+    -DWBXML_SUPPORT_SYNCML:BOOL=ON \
+    -DWBXML_SUPPORT_WML:BOOL=ON \
+    -DWBXML_SUPPORT_WTA:BOOL=ON \
+    -DWBXML_SUPPORT_WV:BOOL=ON \
+    ..
 popd
 make -C %{_target_platform} %{?_smp_mflags}
 
 %install
 make -C %{_target_platform} install/fast DESTDIR=$RPM_BUILD_ROOT
-rm -r $RPM_BUILD_ROOT/usr/share/doc/%{name}
 
 %check
 cd %{_target_platform}
-ctest
+ctest %{?_smp_mflags}
 
 %post -p /sbin/ldconfig
 
 %postun -p /sbin/ldconfig
 
 %files
-%doc AUTHORS BUGS ChangeLog COPYING GNU-LGPL NEWS README References THANKS TODO
+%license COPYING GNU-LGPL
+%doc BUGS ChangeLog README References THANKS TODO
 %{_bindir}/*
 %{_libdir}/libwbxml2.so.*
 
 %files devel
-%{_datadir}/cmake/Modules/*
+# In order not to run-require cmake, own the directory
+%{_datadir}/cmake
 %{_includedir}/*
 %{_libdir}/libwbxml2.so
 %{_libdir}/pkgconfig/libwbxml2.pc
 
 %changelog
+* Wed Aug 16 2017 Petr Pisar <ppisar@redhat.com> - 0.11.6-1
+- 0.11.6 bump
+
+* Wed Jul 26 2017 Fedora Release Engineering <releng@fedoraproject.org> - 0.11.5-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_27_Mass_Rebuild
+
+* Mon Feb 13 2017 Petr Pisar <ppisar@redhat.com> - 0.11.5-1
+- 0.11.5 bump
+
+* Fri Feb 10 2017 Fedora Release Engineering <releng@fedoraproject.org> - 0.11.3-5
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_26_Mass_Rebuild
+
+* Thu Feb 04 2016 Fedora Release Engineering <releng@fedoraproject.org> - 0.11.3-4
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_24_Mass_Rebuild
+
+* Mon Jul 27 2015 Petr Pisar <ppisar@redhat.com> - 0.11.3-3
+- Require gcc instead of glibc-headers (bug #1230475)
+
+* Wed Jun 17 2015 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.11.3-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_23_Mass_Rebuild
+
+* Wed Apr 08 2015 Petr Pisar <ppisar@redhat.com> - 0.11.3-1
+- 0.11.3 bump
+
+* Sun Aug 17 2014 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.11.2-5
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_21_22_Mass_Rebuild
+
+* Sat Jun 07 2014 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.11.2-4
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_21_Mass_Rebuild
+
 * Sat Aug 03 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.11.2-3
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_20_Mass_Rebuild
 

--- a/libwbxml.spec
+++ b/libwbxml.spec
@@ -1,19 +1,7 @@
+Summary:        Library and tools to parse, encode and handle WBXML documents
 Name:           libwbxml
 Version:        0.11.6
 Release:        1%{?dist}
-Summary:        Library and tools to parse, encode and handle WBXML documents
-## Used and installed:
-# NEWS:                             ???
-# GNU-LGPL:                         LGPLv2+
-# COPYING:                          LGPLv2+
-# Other files:                      LGPLv2+
-## Not installed:
-# cmake/modules/FindECal1.2.cmake:  BSD
-# cmake/modules/FindIconv.cmake:    GPLv3+
-## Not used:
-# win32/leaktrack/leaktrack.h:      GPLv2+
-# win32/leaktrack/COPYING.txt:      BSD with advertising
-# win32/expat/README.txt:           MIT
 License:        LGPLv2+
 URL:            https://github.com/%{name}/%{name}
 Source:         http://downloads.sourceforge.net/%{name}/%{name}-%{version}.tar.bz2

--- a/sogo.spec
+++ b/sogo.spec
@@ -33,7 +33,7 @@ URL:          http://www.inverse.ca/contributions/sogo.html
 Group:        Productivity/Groupware
 Source:       https://github.com/inverse-inc/sogo/archive/SOGo-%{sogo_version}.tar.gz
 Prefix:       /usr
-AutoReqProv:  off
+AutoReqProv:  no
 Requires:     gnustep-base >= 1.23, sope%{sope_major_version}%{sope_minor_version}-core, httpd, sope%{sope_major_version}%{sope_minor_version}-core, sope%{sope_major_version}%{sope_minor_version}-appserver, sope%{sope_major_version}%{sope_minor_version}-ldap, sope%{sope_major_version}%{sope_minor_version}-cards >= %{sogo_version}, sope%{sope_major_version}%{sope_minor_version}-gdl1-contentstore >= %{sogo_version}, sope%{sope_major_version}%{sope_minor_version}-sbjson, libmemcached, memcached, tmpwatch, zip
 BuildRoot:    %{_tmppath}/%{name}-%{version}-%{release}
 BuildRequires:  gcc-objc gnustep-base gnustep-make gnustep-base-devel sope%{sope_major_version}%{sope_minor_version}-appserver-devel sope%{sope_major_version}%{sope_minor_version}-core-devel sope%{sope_major_version}%{sope_minor_version}-ldap-devel sope%{sope_major_version}%{sope_minor_version}-mime-devel sope%{sope_major_version}%{sope_minor_version}-xml-devel sope%{sope_major_version}%{sope_minor_version}-gdl1-devel sope%{sope_major_version}%{sope_minor_version}-sbjson-devel libmemcached-devel sed libcurl-devel openldap-devel %{?oc_build_depends}
@@ -70,7 +70,7 @@ and to reduce the load of the transactions on the server.
 Summary:      Command-line toolsuite for SOGo
 Group:        Productivity/Groupware
 Requires:     sogo = %{sogo_version}
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description -n sogo-tool
 Administrative tool for SOGo that provides the following internal commands:
@@ -82,7 +82,7 @@ Administrative tool for SOGo that provides the following internal commands:
 %package -n sogo-slapd-sockd
 Summary:      SOGo backend for slapd and back-sock
 Group:        Productivity/Groupware
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description -n sogo-slapd-sockd
 SOGo backend for slapd and back-sock, enabling access to private addressbooks
@@ -91,7 +91,7 @@ via LDAP.
 %package -n sogo-ealarms-notify
 Summary:      SOGo utility for executing email alarms
 Group:        Productivity/Groupware
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description -n sogo-ealarms-notify
 SOGo utility executed each minute via a cronjob for executing email alarms.
@@ -101,7 +101,7 @@ Summary:      SOGo module to handle ActiveSync requests
 Group:        Productivity/Groupware
 Requires:     libwbxml, sogo = %{sogo_version}
 BuildRequires: libwbxml-devel
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description -n sogo-activesync
 SOGo module to handle ActiveSync requests
@@ -109,7 +109,7 @@ SOGo module to handle ActiveSync requests
 %package -n sogo-devel
 Summary:      Development headers and libraries for SOGo
 Group:        Development/Libraries/Objective C
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description -n sogo-devel
 Development headers and libraries for SOGo. Needed to create modules.
@@ -118,7 +118,7 @@ Development headers and libraries for SOGo. Needed to create modules.
 Summary:      Storage backend for folder abstraction.
 Group:        Development/Libraries/Objective C
 Requires:     sope%{sope_major_version}%{sope_minor_version}-gdl1
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description -n sope%{sope_major_version}%{sope_minor_version}-gdl1-contentstore
 The storage backend implements the "low level" folder abstraction, which is
@@ -131,7 +131,7 @@ name "SOPE" (SKYRiX Object Publishing Environment) is inspired by ZOPE.
 Summary:      Development files for the GNUstep database libraries
 Group:        Development/Libraries/Objective C
 Requires:     sope%{sope_major_version}%{sope_minor_version}-gdl1
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description -n sope%{sope_major_version}%{sope_minor_version}-gdl1-contentstore-devel
 This package contains the header files for SOPE's GDLContentStore library.
@@ -142,7 +142,7 @@ name "SOPE" (SKYRiX Object Publishing Environment) is inspired by ZOPE.
 %package -n sope%{sope_major_version}%{sope_minor_version}-cards
 Summary:      SOPE versit parsing library for iCal and VCard formats
 Group:        Development/Libraries/Objective C
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description -n sope%{sope_major_version}%{sope_minor_version}-cards
 SOPE versit parsing library for iCal and VCard formats
@@ -151,7 +151,7 @@ SOPE versit parsing library for iCal and VCard formats
 Summary:      SOPE versit parsing library for iCal and VCard formats
 Group:        Development/Libraries/Objective C
 Requires:     sope%{sope_major_version}%{sope_minor_version}-cards
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description -n sope%{sope_major_version}%{sope_minor_version}-cards-devel
 SOPE versit parsing library for iCal and VCard formats
@@ -160,7 +160,7 @@ SOPE versit parsing library for iCal and VCard formats
 %package openchange-backend
 Summary:      SOGo backend for OpenChange
 Group:        Productivity/Groupware
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description openchange-backend
 SOGo backend for OpenChange

--- a/sogo.spec
+++ b/sogo.spec
@@ -1,4 +1,4 @@
-%define sogo_version 4.3.0
+%define sogo_version 4.3.2
 %define sope_major_version 4
 %define sope_minor_version 9
 %define sogo_release 1
@@ -432,6 +432,9 @@ fi
 
 # ********************************* changelog *************************
 %changelog
+* Fri May 22 2020  Stephane de Labrusse <stephdl@de-labrusse.fr>
+- Bump to 4.3.2
+
 * Thu Dec 19 2019 Stephane de Labrusse <stephdl@de-labrusse.fr>
 - Bump to 4.2.0
 

--- a/sogo.spec
+++ b/sogo.spec
@@ -1,7 +1,7 @@
 %define sogo_version 4.3.2
+%define sogo_release 1
 %define sope_major_version 4
 %define sope_minor_version 9
-%define sogo_release 1
 
 # We disable OpenChange builds since it's not maintained
 %define enable_openchange 0

--- a/sogo.spec
+++ b/sogo.spec
@@ -1,4 +1,4 @@
-%define sogo_version 4.2.0
+%define sogo_version 4.3.0
 %define sope_major_version 4
 %define sope_minor_version 9
 %define sogo_release 1

--- a/sope.spec
+++ b/sope.spec
@@ -1,5 +1,5 @@
 %define sope_source_version 4.3.2
-%define sope_release 20200522_0800
+%define sope_release 1
 %define sope_major_version 4
 %define sope_minor_version 9
 %define sope_makeflags -k
@@ -14,7 +14,8 @@
 Summary:      SOPE
 Name:         sope%{sope_major_version}%{sope_minor_version}
 Version:      %{sope_major_version}.%{sope_minor_version}
-Release:      %{sope_release}%{?dist}
+Epoch:        1
+Release:      %{sope_source_version}.%{sope_release}%{?dist}
 Vendor:       http://www.opengroupware.org
 Packager:     Inverse inc. <info@inverse.ca>
 License:      GPL

--- a/sope.spec
+++ b/sope.spec
@@ -20,7 +20,7 @@ Packager:     Inverse inc. <info@inverse.ca>
 License:      GPL
 URL:          https://github.com/inverse-inc/sope
 Group:        Development/Libraries/Objective C
-AutoReqProv:  off
+AutoReqProv:  no
 Source:       https://github.com/inverse-inc/sope/archive/SOPE-%{sope_source_version}.tar.gz
 Prefix:       /usr
 BuildRoot:    %{_tmppath}/%{name}-%{version}-%{release}-root
@@ -37,7 +37,7 @@ sope
 %package xml
 Summary:      SOPE libraries for XML processing
 Group:        Development/Libraries/Objective C
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description xml
 The SOPE libraries for XML processing contain:
@@ -53,7 +53,7 @@ name "SOPE" (SKYRiX Object Publishing Environment) is inspired by ZOPE.
 Summary:      Development files for the SOPE XML libraries
 Group:        Development/Libraries/Objective C
 Requires:     sope%{sope_major_version}%{sope_minor_version}-xml libxml2-devel
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description xml-devel
 This package contains the development files of the SOPE XML libraries.
@@ -89,7 +89,7 @@ Project homepage is: http://code.google.com/p/json-framework/
 Summary:      Core libraries of the SOPE application server
 Group:        Development/Libraries/Objective C
 Requires:     sope%{sope_major_version}%{sope_minor_version}-xml
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description core
 The SOPE core libraries contain:
@@ -104,7 +104,7 @@ name "SOPE" (SKYRiX Object Publishing Environment) is inspired by ZOPE.
 Summary:      Development files for the SOPE core libraries
 Group:        Development/Libraries/Objective C
 Requires:     sope%{sope_major_version}%{sope_minor_version}-core
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description core-devel
 This package contains the header files for the SOPE core
@@ -118,7 +118,7 @@ name "SOPE" (SKYRiX Object Publishing Environment) is inspired by ZOPE.
 Summary:      SOPE libraries for MIME processing
 Group:        Development/Libraries/Objective C
 Requires:     sope%{sope_major_version}%{sope_minor_version}-core sope%{sope_major_version}%{sope_minor_version}-xml
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description mime
 The SOPE libraries for MIME processing contain:
@@ -134,7 +134,7 @@ name "SOPE" (SKYRiX Object Publishing Environment) is inspired by ZOPE.
 Summary:      Development files for the SOPE MIME libraries
 Group:        Development/Libraries/Objective C
 Requires:     sope%{sope_major_version}%{sope_minor_version}-mime
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description mime-devel
 This package contains the development files of the SOPE
@@ -148,7 +148,7 @@ name "SOPE" (SKYRiX Object Publishing Environment) is inspired by ZOPE.
 Summary:      SOPE application server libraries
 Group:        Development/Libraries/Objective C
 Requires:     sope%{sope_major_version}%{sope_minor_version}-xml sope%{sope_major_version}%{sope_minor_version}-core sope%{sope_major_version}%{sope_minor_version}-mime
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description appserver
 The SOPE application server libraries provide:
@@ -168,7 +168,7 @@ name "SOPE" (SKYRiX Object Publishing Environment) is inspired by ZOPE.
 Summary:      Development files for the SOPE application server libraries
 Group:        Development/Libraries/Objective C
 Requires:     sope%{sope_major_version}%{sope_minor_version}-appserver
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description appserver-devel
 This package contains the development files for the SOPE application server
@@ -182,7 +182,7 @@ name "SOPE" (SKYRiX Object Publishing Environment) is inspired by ZOPE.
 Summary:      SOPE libraries for LDAP access
 Group:        Development/Libraries/Objective C
 Requires:     sope%{sope_major_version}%{sope_minor_version}-core sope%{sope_major_version}%{sope_minor_version}-xml
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description ldap
 The SOPE libraries for LDAP access contain an Objective-C wrapper for
@@ -195,7 +195,7 @@ name "SOPE" (SKYRiX Object Publishing Environment) is inspired by ZOPE.
 Summary:      Development files for the SOPE LDAP libraries
 Group:        Development/Libraries/Objective C
 Requires:     sope%{sope_major_version}%{sope_minor_version}-ldap
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description ldap-devel
 This package contains the development files of the SOPE
@@ -209,7 +209,7 @@ name "SOPE" (SKYRiX Object Publishing Environment) is inspired by ZOPE.
 Summary:      GNUstep database libraries for SOPE
 Group:        Development/Libraries/Objective C
 Requires:     sope%{sope_major_version}%{sope_minor_version}-core sope%{sope_major_version}%{sope_minor_version}-xml
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description gdl1
 This package contains a fork of the GNUstep database libraries used
@@ -222,7 +222,7 @@ name "SOPE" (SKYRiX Object Publishing Environment) is inspired by ZOPE.
 Summary:      PostgreSQL connector for SOPE's fork of the GNUstep database environment
 Group:        Development/Libraries/Objective C
 Requires:     sope%{sope_major_version}%{sope_minor_version}-gdl1 postgresql-libs
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description gdl1-postgresql
 This package contains the PostgreSQL connector for SOPE's fork of the
@@ -237,7 +237,7 @@ Summary:      Oracle connector for SOPE's fork of the GNUstep database environme
 Group:        Development/Libraries/Objective C
 Requires:     sope%{sope_major_version}%{sope_minor_version}-gdl1
 #Requires:    oracle-instantclient-basic
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description gdl1-oracle
 This package contains the Oracle connector for SOPE's fork of the
@@ -248,7 +248,7 @@ GNUstep database libraries.
 Summary:      MySQL connector for SOPE's fork of the GNUstep database environment
 Group:        Development/Libraries/Objective C
 Requires:     sope%{sope_major_version}%{sope_minor_version}-gdl1
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description gdl1-mysql
 This package contains the MySQL connector for SOPE's fork of the
@@ -259,7 +259,7 @@ GNUstep database libraries.
 #Summary:      SQLite3 connector for SOPE's fork of the GNUstep database environment
 #Group:        Development/Libraries/Objective C
 #Requires:     sope%{sope_major_version}%{sope_minor_version}-gdl1
-#AutoReqProv:  off
+#AutoReqProv:  no
 #
 #%description gdl1-sqlite3
 #This package contains the SQLite3 connector for SOPE's fork of the
@@ -272,7 +272,7 @@ GNUstep database libraries.
 Summary:      Development files for the GNUstep database libraries
 Group:        Development/Libraries/Objective C
 Requires:     sope%{sope_major_version}%{sope_minor_version}-gdl1
-AutoReqProv:  off
+AutoReqProv:  no
 
 %description gdl1-devel
 This package contains the header files for SOPE's fork of the GNUstep
@@ -284,7 +284,7 @@ name "SOPE" (SKYRiX Object Publishing Environment) is inspired by ZOPE.
 #%package -n mod_ngobjweb
 #Summary:      mod_ngobjweb apache module
 #Group:        Development/Libraries
-#AutoReqProv:  off
+#AutoReqProv:  no
 #Requires:     %{ngobjweb_requires}
 #
 #%description -n mod_ngobjweb

--- a/sope.spec
+++ b/sope.spec
@@ -1,5 +1,5 @@
-%define sope_source_version 4.2.0
-%define sope_release 20191218_1900
+%define sope_source_version 4.3.0
+%define sope_release 20190120_1700
 %define sope_major_version 4
 %define sope_minor_version 9
 %define sope_makeflags -k

--- a/sope.spec
+++ b/sope.spec
@@ -1,5 +1,5 @@
-%define sope_source_version 4.3.0
-%define sope_release 20190120_1700
+%define sope_source_version 4.3.2
+%define sope_release 20200522_0800
 %define sope_major_version 4
 %define sope_minor_version 9
 %define sope_makeflags -k
@@ -505,6 +505,8 @@ rm -fr ${RPM_BUILD_ROOT}
 
 # ********************************* changelog *************************
 %changelog
+* Fri May 22 2020  Stephane de Labrusse <stephdl@de-labrusse.fr>
+- Bump to 4.3.2
 * Thu Dec 19 2019 Stephane de Labrusse <stephdl@de-labrusse.fr>
 - Bump to 4.2.0
 * Tue Aug 27 2019 Stephane de Labrusse <stephdl@de-labrusse.fr>


### PR DESCRIPTION
Some (breaking ?) changes

we switch to no for AutoReqProv like the doc states  : http://ftp.rpm.org/max-rpm/s1-rpm-depend-auto-depend.html
```
-AutoReqProv:  off
+AutoReqProv:  no
```

we have upgraded libwbxml to 0.11.6

the build is good and SOGo is up after the installation.