### PR TITLE
Bump to 5.1.1

### DIFF
--- a/sogo.spec
+++ b/sogo.spec
@@ -1,4 +1,4 @@
-%define sogo_version 5.1.0
+%define sogo_version 5.1.1
 %define sogo_release 1
 %define sope_major_version 4
 %define sope_minor_version 9

--- a/sope.spec
+++ b/sope.spec
@@ -1,4 +1,4 @@
-%define sope_source_version 5.1.0
+%define sope_source_version 5.1.1
 %define sope_release 1
 %define sope_major_version 4
 %define sope_minor_version 9


### PR DESCRIPTION
Sogo 5.1.1 addresses _White font color on white quick search box_ :

https://www.sogo.nu/bugs/view.php?id=5291

This issue is reported by the nethserver community too:
https://community.nethserver.org/t/sogo-problems-with-signatures-and-search/18592
